### PR TITLE
Fix compilation on Linux

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,62 @@
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+name: Continuous integration
+
+jobs:
+  ci:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        rust:
+          - stable
+          - nightly
+          - 1.53.0
+
+    steps:
+      - name: Install deps
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get install -y libdbus-1-dev
+
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ runner.os }}-${{ matrix.rust }}-${{ hashFiles('Cargo.lock') }}
+
+      - uses: actions-rs/cargo@v1
+        name: Build
+        with:
+          command: build
+
+      - uses: actions-rs/cargo@v1
+        name: Test
+        with:
+          command: test
+
+      - uses: actions-rs/cargo@v1
+        name: Format
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - uses: actions-rs/cargo@v1
+        name: Clippy
+        if: matrix.rust == 'stable'
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/terra-rust-api/src/client.rs
+++ b/terra-rust-api/src/client.rs
@@ -286,7 +286,7 @@ impl<'a> Terra<'a> {
         }
     }
     /// helper function to generate a 'StdSignMsg' & 'Signature' blocks to be used to broadcast a transaction
-
+    #[allow(clippy::too_many_arguments)]
     fn generate_transaction_to_broadcast_fees(
         chain_id: String,
         account_number: u64,

--- a/terra-rust-wallet/src/errors.rs
+++ b/terra-rust-wallet/src/errors.rs
@@ -44,16 +44,31 @@ error_chain! {
 #[derive(Error, Debug)]
 pub enum TerraRustWalletError {
     #[error(transparent)]
-    KeyringError(#[from] ::keyring::KeyringError),
+    KeyringError(#[from] KeyringErrorAdapter),
     #[error(transparent)]
     SerdeJsonError(#[from] ::serde_json::Error),
 
     #[error("Terra Wallet `{key}` Key not found Error")]
     KeyNotFound {
         key: String,
-        source: keyring::KeyringError,
+        source: KeyringErrorAdapter,
     },
 
     #[error("unknown Terra-Rust Wallet error")]
     Unknown,
+}
+
+/// Workaround type to provide [Sync] on Linux.
+///
+/// On Linux, [keyring::KeyringError] does not implement `Sync` due to depending
+/// on an older version of the `dbus` crate. This prevents usage of `anyhow`. This
+/// wrapper is used to bypass that issue on Linux.
+#[derive(Error, Debug)]
+#[error(transparent)]
+pub struct KeyringErrorAdapter(anyhow::Error);
+
+impl From<keyring::KeyringError> for KeyringErrorAdapter {
+    fn from(e: keyring::KeyringError) -> Self {
+        KeyringErrorAdapter(anyhow::anyhow!("Keyring error: {:?}", e))
+    }
 }


### PR DESCRIPTION
Fixes #1. This is a slightly hacky fix by wrapping up the `KeyringError` type in an adapter type that simply uses `anyhow::Error` and its `Debug` implementation. This bypasses the fact that `KeyringError` itself is not `Sync` on Linux. A better solution would be to update the dependency on `dbus` present within `keyring`, but it's unclear if that library is still maintained.