### PR TITLE
use default for sequence deserialize

### DIFF
--- a/terra-rust-api/src/client/auth_types.rs
+++ b/terra-rust-api/src/client/auth_types.rs
@@ -16,6 +16,6 @@ pub struct AuthAccount {
     /// The account number
     pub account_number: u64,
     /// The sequence. This is used to avoid 'double transmitting' a transaction
-    #[serde(with = "terra_opt_u64_format")]
+    #[serde(default, with = "terra_opt_u64_format")]
     pub sequence: Option<u64>,
 }


### PR DESCRIPTION
The `with = "terra_opt_u64_format"` only applies when the actual field is present. So if the server reply does not include a `sequence` field (eg for a new account) then deserialization will just fall without the `default`

```
[2022-02-05T01:47:50Z ERROR do_swap] Reqwest HTTP(s) Error
[2022-02-05T01:47:50Z ERROR do_swap] because: error decoding response body: missing field `sequence` at line 1 column 144
[2022-02-05T01:47:50Z ERROR do_swap] because: missing field `sequence` at line 1 column 144
```
